### PR TITLE
Fix RecursionError in equality tests

### DIFF
--- a/bible/bible.py
+++ b/bible/bible.py
@@ -149,12 +149,8 @@ class Verse:
             raise RangeError(err)
 
     def __eq__(self, other):
-        if self.translation is None and other.translation is None:
-            # if both transl are None, they won't equate when they should
-            return (self.book == other.book and self.chapter == other.chapter  \
-                    and self.verse == other.verse)
-        else:  # at least 1 translation is set, so == works
-            return self == other
+        return (self.book == other.book and self.chapter == other.chapter
+            and self.verse == other.verse and self.translation == other.translation)
 
     def __unicode__(self):
         return self.format()

--- a/tests/test_bible.py
+++ b/tests/test_bible.py
@@ -103,6 +103,9 @@ class TestVerse(unittest.TestCase):
         other = bible.Verse('Eph 2:10')
         self.assertTrue(self.eph2_10 == other)
 
+    def test_equals_with_both_translations_set(self):
+        self.assertTrue(bible.Verse(1, 2, 3, 'kjv') == bible.Verse(1, 2, 3, 'kjv'))
+
     def test_format(self):
         self.assertEqual(self.acts_8_37_esv.format('b c:v'),
                          self.acts_8_37_esv.format('B C:V'))


### PR DESCRIPTION
When translations are set equality testing with `==` would result in infinite recursion.

This removes the recursion to avoid the problem.